### PR TITLE
Clarify that the zip code should be the five-digit form

### DIFF
--- a/index.html
+++ b/index.html
@@ -133,7 +133,7 @@
           	<option value="WY">Wyoming</option>
           </select>
 
-          <label for="postal-code-input">Zip Code</label>
+          <label for="postal-code-input">Zip Code (five digit)</label>
           <input class="postal-code" id="postal-code-input" type="number" name="postal-code" postal-code placeholder="20500" max="99999" min="1" required>
         </fieldset>
         <div class="button-div">


### PR DESCRIPTION
Nine-digit zip codes are unnecessary here (even if furriners copy and paste them from other people's published addresses).